### PR TITLE
remove unnecessary state variable and useEffect dependencies

### DIFF
--- a/src/FhirClientProvider.js
+++ b/src/FhirClientProvider.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useState } from "react";
 import FHIR from "fhirclient";
 import Stack from "@mui/material/Stack";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -8,11 +8,10 @@ import ErrorComponent from "./components/ErrorComponent";
 
 export default function FhirClientProvider(props) {
   const [client, setClient] = useState(null);
-  const [error, setError] = useState("");
   const [patient, setPatient] = useState(null);
-  const [ready, setReady] = useState(false);
+  const [error, setError] = useState(null);
 
-  const getPatient = useCallback(async () => {
+  const getPatient = async (client) => {
     if (!client) return;
 
     //this is a workaround for when patient id is NOT embedded within the JWT token
@@ -22,36 +21,31 @@ export default function FhirClientProvider(props) {
       return client.request("/Patient/" + queryPatientId);
     }
     // Get the Patient resource
-    return await client.patient.read().then((pt) => {
-      return pt;
-    });
-  }, [client]);
+    return await client.patient.read();
+  };
 
   useEffect(() => {
     FHIR.oauth2.ready().then(
       (client) => {
-        console.log("Auth ready..");
+        console.log("Auth complete, client ready.");
         setClient(client);
+        getPatient(client)
+            .then((result) => {
+              console.log("Patient loaded.");
+              setPatient(result);
+              setError(null);
+            })
+            .catch((e) => {
+              setError(e);
+            });
       },
       (error) => {
-        console.log("Auth error ", error);
+        console.log("Auth error: ", error);
         setError(error);
       }
     );
   }, []);
 
-  useEffect(() => {
-    if (!client) return;
-    getPatient()
-      .then((result) => {
-        setPatient(result);
-        setReady(true);
-        setError("");
-      })
-      .catch((e) => {
-        setError(e);
-      });
-  }, [client, getPatient]);
 
   return (
     <FhirClientContext.Provider
@@ -65,7 +59,7 @@ export default function FhirClientProvider(props) {
           }
 
           // if client and patient are available render the children component(s)
-          if (!error && ready) {
+          if (client && patient) {
             return props.children;
           }
 


### PR DESCRIPTION
- both using useCallback and the dependency array for useEffect seem a bit messy and not needed if the `getPatient` function doesn't depend on state. Passing client to getPatient is easy enough and avoids this.
- remove `ready` state variable, which is a just an alias for patient not being null and clutters the state